### PR TITLE
Wall Tool Board patches for 3 different mods

### DIFF
--- a/1.3/Patches/ToolBoard_Patch_JDSForge.xml
+++ b/1.3/Patches/ToolBoard_Patch_JDSForge.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+	
+    <Operation Class="PatchOperationFindMod">
+        <mods>
+            <li>[JDS] The Forge - Anvil</li>
+        </mods>
+        <match Class="PatchOperationSequence">
+            <operations>
+                <li Class="PatchOperationAdd">
+                    <xpath>*/ThingDef[@Name="JDSForgeBenchBase"]/comps/li[@Class="CompProperties_AffectedByFacilities"]/linkableFacilities</xpath>
+                    <value>
+                        <li>WallToolBoard</li>
+                    </value>
+                </li>
+            </operations>
+        </match>
+    </Operation>
+
+</Patch>

--- a/1.3/Patches/ToolBoard_Patch_RWoM.xml
+++ b/1.3/Patches/ToolBoard_Patch_RWoM.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+<!--Patching 3 of RimWorld of Magics structures-->
+    <Operation Class="PatchOperationFindMod">
+        <mods>
+            <li>A RimWorld of Magic</li>
+        </mods>
+        <match Class="PatchOperationSequence">
+            <operations>
+                <li Class="PatchOperationAdd"> <!--gemcrafting table-->
+                    <xpath>*/ThingDef[defName="TableGemcutting"]/comps/li[@Class="CompProperties_AffectedByFacilities"]/linkableFacilities</xpath>
+                    <value>
+                        <li>WallToolBoard</li>
+                    </value>
+                </li>
+                <li Class="PatchOperationAdd"> <!--scribing table-->
+                    <xpath>*/ThingDef[defName="TableMagicPrinter"]/comps/li[@Class="CompProperties_AffectedByFacilities"]/linkableFacilities</xpath>
+                    <value>
+                        <li>WallToolBoard</li>
+                    </value>
+                </li>
+                <li Class="PatchOperationAdd"> <!--arcane forge-->
+                    <xpath>*/ThingDef[defName="TableArcaneForge"]/comps/li[@Class="CompProperties_AffectedByFacilities"]/linkableFacilities</xpath>
+                    <value>
+                        <li>WallToolBoard</li>
+                    </value>
+                </li>
+            </operations>
+        </match>
+    </Operation>
+
+</Patch>

--- a/1.3/Patches/ToolBoard_Patch_Ratkin.xml
+++ b/1.3/Patches/ToolBoard_Patch_Ratkin.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+	
+    <Operation Class="PatchOperationFindMod">
+        <mods>
+            <li>NewRatkinPlus</li>
+        </mods>
+        <match Class="PatchOperationSequence">
+            <operations>
+                <li Class="PatchOperationAdd">
+                    <xpath>*/ThingDef[defName="RK_HandTailoringBench"]/comps/li[@Class="CompProperties_AffectedByFacilities"]/linkableFacilities</xpath>
+                    <value>
+                        <li>WallToolBoard</li>
+                    </value>
+                </li>
+                <li Class="PatchOperationAdd">
+                    <xpath>*/ThingDef[defName="RK_ElectricTailoringBench"]/comps/li[@Class="CompProperties_AffectedByFacilities"]/linkableFacilities</xpath>
+                    <value>
+                        <li>WallToolBoard</li>
+                    </value>
+                </li>
+                <li Class="PatchOperationAdd">
+                    <xpath>*/ThingDef[defName="RK_FueledSmithy"]/comps/li[@Class="CompProperties_AffectedByFacilities"]/linkableFacilities</xpath>
+                    <value>
+                        <li>WallToolBoard</li>
+                    </value>
+                </li>
+                <li Class="PatchOperationAdd">
+                    <xpath>*/ThingDef[defName="RK_ElectricSmithy"]/comps/li[@Class="CompProperties_AffectedByFacilities"]/linkableFacilities</xpath>
+                    <value>
+                        <li>WallToolBoard</li>
+                    </value>
+                </li>
+            </operations>
+        </match>
+    </Operation>
+
+</Patch>


### PR DESCRIPTION
Patched workbenches from Rimworld of Magic to match wall tool board with tool cabinet functionality (High traffic mod)
Did the same process for both NewRatkin+ (race/faction mod with medium traffic) as well as [JDS] The Forge (core mod for JDS with medium/low traffic)